### PR TITLE
Polish apply cadence cards and interactions

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -46,44 +46,89 @@
           <aside class="callout" data-animate>
             <h3>Application cadence</h3>
             <p class="text-muted">
-              Onboarding in the club happens in stages. First, you must attend a callout. After that, you need to show
-              genuine interest—demonstrating curiosity and eagerness about what we’re building. We only accept serious
-              applicants who are committed to participating.
+              Onboarding happens in stages. First, attend a callout. Then, show genuine interest—curiosity and eagerness
+              about what we’re building. We’re only moving forward with serious applicants.
             </p>
             <div style="margin-top: 1.5rem">
               <div class="metrics-grid">
-                <div class="metric-card" tabindex="0">
+                <div
+                  class="metric-card cadence-card"
+                  data-card
+                  data-week="1"
+                  data-front-label="Week 1 Callouts &amp; Applications card. Front face."
+                  data-back-label="Week 1 Callouts &amp; Applications card. Back face. Join us at WALC 0001 at 5 PM on 4th of October."
+                  role="button"
+                  tabindex="0"
+                  aria-pressed="false"
+                  aria-label="Week 1 Callouts &amp; Applications card. Front face."
+                >
                   <div class="card-inner">
                     <div class="card-face card-front">
-                      <p class="card-week">Week 1</p>
-                      <strong>Callouts &amp; Applications</strong>
+                      <div class="card-surface">
+                        <p class="card-week">Week 1</p>
+                        <strong>Callouts &amp; Applications</strong>
+                      </div>
                     </div>
                     <div class="card-face card-back">
-                      <p class="card-back-text">Join us at WALC 0001 at 5 PM on 4th of October.</p>
+                      <div class="card-surface">
+                        <p class="card-back-text">Join us at WALC 0001 at 5 PM on 4th of October.</p>
+                      </div>
                     </div>
                   </div>
                 </div>
-                <div class="metric-card" tabindex="0">
+                <div
+                  class="metric-card cadence-card"
+                  data-card
+                  data-week="2"
+                  data-front-label="Week 2 Orientation card. Front face."
+                  data-back-label="Week 2 Orientation card. Back face. Movie screening night — a very special movie. Attend Orientation to gain Cloud Points."
+                  data-easter-egg="clapboard"
+                  role="button"
+                  tabindex="0"
+                  aria-pressed="false"
+                  aria-label="Week 2 Orientation card. Front face."
+                >
                   <div class="card-inner">
                     <div class="card-face card-front">
-                      <p class="card-week">Week 2</p>
-                      <strong>Orientation</strong>
+                      <div class="card-surface">
+                        <p class="card-week">Week 2</p>
+                        <strong>Orientation</strong>
+                      </div>
                     </div>
                     <div class="card-face card-back">
-                      <p class="card-back-tag orientation-tag">Now Showing</p>
-                      <p class="card-back-text">Movie screening night – a very special movie.</p>
-                      <p class="card-back-text">Earn Cloud Points by attending Orientation Night.</p>
+                      <div class="card-surface">
+                        <p class="card-back-tag orientation-tag">
+                          <span class="orientation-icon" aria-hidden="true" data-clapboard></span>
+                          Now Showing
+                        </p>
+                        <p class="card-back-text card-back-lead">Movie screening night — a very special movie.</p>
+                        <p class="card-back-text">Attend Orientation to gain Cloud Points.</p>
+                      </div>
                     </div>
                   </div>
                 </div>
-                <div class="metric-card" tabindex="0">
+                <div
+                  class="metric-card cadence-card"
+                  data-card
+                  data-week="3"
+                  data-front-label="Week 3 CloudNight card. Front face."
+                  data-back-label="Week 3 CloudNight card. Back face. Let the cloud networking begin."
+                  role="button"
+                  tabindex="0"
+                  aria-pressed="false"
+                  aria-label="Week 3 CloudNight card. Front face."
+                >
                   <div class="card-inner">
                     <div class="card-face card-front">
-                      <p class="card-week">Week 3</p>
-                      <strong>CloudNight</strong>
+                      <div class="card-surface">
+                        <p class="card-week">Week 3</p>
+                        <strong>CloudNight</strong>
+                      </div>
                     </div>
                     <div class="card-face card-back">
-                      <p class="card-back-text">Let the cloud networking begin.</p>
+                      <div class="card-surface">
+                        <p class="card-back-text">Let the cloud networking begin.</p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -552,101 +552,371 @@ footer.site-footer {
 
 .metric-card {
   position: relative;
-  perspective: 1200px;
-  border-radius: 0.65rem;
-  height: 100%;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.6rem;
   min-height: 200px;
-  outline: none;
+}
+
+.metric-card strong {
+  font-size: 1.58rem;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1.25;
+  margin: 0;
+}
+
+.metric-card span {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.cadence-card {
+  --card-radius: 0.95rem;
+  --flip-duration: 0.32s;
+  --flip-easing: cubic-bezier(0.55, 0, 0.55, 0.2);
+  --layer-shift-x: 0px;
+  --layer-shift-y: 0px;
+  --edge-angle: 0deg;
+  isolation: isolate;
+  display: block;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: 0 24px 48px rgba(6, 12, 24, 0.45);
+  perspective: 1600px;
+  min-height: 200px;
   cursor: pointer;
+  outline: none;
+  touch-action: manipulation;
+  opacity: 0;
+  transform: translateY(28px);
+  transition:
+    opacity 0.65s cubic-bezier(0.33, 1, 0.68, 1) var(--card-reveal-delay, 0ms),
+    transform 0.65s cubic-bezier(0.33, 1, 0.68, 1) var(--card-reveal-delay, 0ms),
+    box-shadow 0.45s cubic-bezier(0.33, 1, 0.68, 1),
+    filter 0.45s cubic-bezier(0.33, 1, 0.68, 1);
 }
 
-.metric-card:focus-visible {
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
+.callout.visible .cadence-card {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-.metric-card .card-inner {
+.cadence-card:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45), 0 28px 58px rgba(10, 20, 40, 0.55);
+}
+
+.cadence-card::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: calc(var(--card-radius) + 1px);
+  padding: 1px;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(195, 239, 255, 0.65) 0%, rgba(195, 239, 255, 0.12) 55%, transparent 75%) 50% 0%/9px 9px
+      no-repeat,
+    conic-gradient(from 0deg, transparent 0deg, rgba(56, 189, 248, 0.55) 22deg, rgba(56, 189, 248, 0.08) 74deg, transparent 120deg);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  opacity: 0;
+  transform-origin: center;
+  transform: rotate(var(--edge-angle, 0deg));
+  transition: opacity 0.35s ease;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.cadence-card::after {
+  content: "";
+  position: absolute;
+  inset: 6%;
+  border-radius: calc(var(--card-radius) - 0.25rem);
+  background: radial-gradient(circle at 50% 50%, rgba(56, 189, 248, 0.16), rgba(56, 189, 248, 0));
+  opacity: 0;
+  transition: opacity 0.45s ease;
+  filter: blur(8px);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.cadence-card .card-inner {
   position: relative;
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
-  transition: transform 0.7s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition: transform var(--flip-duration, 0.32s) var(--flip-easing, cubic-bezier(0.55, 0, 0.55, 0.2));
+  z-index: 2;
 }
 
-.metric-card:hover .card-inner,
-.metric-card:focus-visible .card-inner,
-.metric-card:active .card-inner {
-  transform: rotateY(180deg);
+.cadence-card .card-inner::after {
+  content: "";
+  position: absolute;
+  inset: 9%;
+  border-radius: calc(var(--card-radius) - 0.45rem);
+  background: radial-gradient(circle at 50% 35%, rgba(56, 189, 248, 0.18), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.5s cubic-bezier(0.33, 1, 0.68, 1);
+  pointer-events: none;
+  z-index: 1;
 }
 
-.metric-card .card-face {
+.cadence-card .card-face {
   position: absolute;
   inset: 0;
-  border-radius: inherit;
-  border: 1px solid var(--card-border);
-  background: rgba(15, 23, 42, 0.88);
-  padding: 1.5rem;
-  box-shadow: var(--shadow-soft);
+  border-radius: var(--card-radius);
+  border: 1px solid rgba(148, 163, 184, 0.24);
   backface-visibility: hidden;
   display: grid;
   align-content: center;
   justify-items: start;
-  gap: 0.75rem;
+  padding: 1.55rem;
+  box-shadow: 0 20px 48px rgba(6, 12, 24, 0.45);
   text-align: left;
+  z-index: 2;
 }
 
-.metric-card .card-front {
+.cadence-card .card-front {
   transform: rotateY(0deg);
+  background: linear-gradient(150deg, rgba(21, 30, 52, 0.96) 0%, rgba(12, 19, 36, 0.92) 100%);
 }
 
-.metric-card .card-back {
+.cadence-card .card-back {
   transform: rotateY(180deg);
+  background: linear-gradient(180deg, rgba(14, 22, 42, 0.94) 0%, rgba(9, 13, 26, 0.9) 100%);
   text-align: left;
 }
 
-.metric-card strong {
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--accent);
-  line-height: 1.3;
-  margin: 0;
+.cadence-card .card-back::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(148, 163, 184, 0.04)),
+    repeating-linear-gradient(0deg, rgba(148, 163, 184, 0.05) 0, rgba(148, 163, 184, 0.05) 1px, transparent 1px, transparent 2px);
+  opacity: 0.15;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  z-index: 1;
 }
 
-.metric-card .card-week {
+.cadence-card .card-surface {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+  transform: translate3d(var(--layer-shift-x, 0px), calc(var(--layer-shift-y, 0px) + var(--card-depth, 0px)), 0);
+  transition: transform 0.55s cubic-bezier(0.33, 1, 0.68, 1), opacity 0.45s ease;
+  z-index: 2;
+}
+
+.cadence-card .card-front .card-surface {
+  --card-depth: 0px;
+  opacity: 1;
+}
+
+.cadence-card .card-back .card-surface {
+  --card-depth: 2px;
+  opacity: 0;
+}
+
+.cadence-card.is-flipped .card-back .card-surface {
+  --card-depth: 0px;
+  opacity: 1;
+}
+
+.cadence-card.is-flipped .card-front .card-surface {
+  opacity: 0;
+}
+
+.cadence-card strong {
+  color: #e0f2ff;
+  letter-spacing: 0.01em;
+  text-shadow: 0 0 12px rgba(56, 189, 248, 0.4);
+}
+
+.cadence-card .card-week {
   margin: 0;
-  font-size: 0.8rem;
-  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: rgba(148, 163, 184, 0.78);
 }
 
-.metric-card .card-back-text {
+.cadence-card .card-back-tag {
   margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.5;
-  color: var(--text-muted);
-}
-
-.metric-card .card-back-tag {
-  margin: 0;
-  font-size: 0.75rem;
-  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--accent);
+  color: rgba(148, 197, 255, 0.95);
 }
 
 .orientation-tag {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.45rem;
 }
 
-.orientation-tag::before {
+.orientation-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  opacity: 0;
+  transform: translateY(-2px) scale(0.6) rotate(-6deg);
+  color: rgba(195, 239, 255, 0.95);
+  filter: drop-shadow(0 0 6px rgba(56, 189, 248, 0.55));
+}
+
+.orientation-icon::before {
   content: "🎬";
   font-size: 0.85rem;
 }
 
-.metric-card:focus-visible .card-face {
+.orientation-icon.is-playing {
+  animation: clapboardTick 0.55s ease-out forwards;
+}
+
+.cadence-card .card-back-text {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.cadence-card .card-back-lead {
+  font-size: 0.94rem;
+  color: #f1f5f9;
+}
+
+.cadence-card .card-back-text + .card-back-text {
+  margin-top: 0.35rem;
+}
+
+.cadence-card.is-engaged {
+  box-shadow: 0 32px 72px rgba(10, 20, 40, 0.6);
+  filter: brightness(1.02);
+}
+
+.cadence-card.is-engaged::before {
+  opacity: 1;
+  animation: edgeOrbit 2.6s linear infinite;
+}
+
+.cadence-card.is-engaged::after,
+.cadence-card.is-engaged .card-inner::after {
+  opacity: 1;
+}
+
+.cadence-card.is-flipped .card-inner {
+  transform: rotateY(180deg);
+}
+
+@media (hover: hover) {
+  .cadence-card:hover .card-inner,
+  .cadence-card:focus-visible .card-inner {
+    transform: rotateY(180deg);
+  }
+}
+
+.cadence-card:focus-visible .card-face {
   border-color: rgba(56, 189, 248, 0.6);
+}
+
+@keyframes edgeOrbit {
+  0% {
+    transform: rotate(var(--edge-angle, 0deg));
+  }
+  100% {
+    transform: rotate(calc(var(--edge-angle, 0deg) + 360deg));
+  }
+}
+
+@keyframes clapboardTick {
+  0% {
+    opacity: 0;
+    transform: translateY(-2px) scale(0.6) rotate(-8deg);
+  }
+  45% {
+    opacity: 1;
+    transform: translateY(0) scale(0.98) rotate(0deg);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(-1px) scale(0.92) rotate(5deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.65) rotate(-10deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cadence-card {
+    transition: none;
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+
+  .cadence-card::before,
+  .cadence-card::after,
+  .cadence-card .card-inner::after {
+    animation: none;
+    opacity: 0;
+  }
+
+  .cadence-card.is-engaged::before,
+  .cadence-card.is-engaged::after,
+  .cadence-card.is-engaged .card-inner::after {
+    opacity: 0;
+  }
+
+  .cadence-card .card-inner {
+    transform: none !important;
+    transition: none;
+  }
+
+  .cadence-card .card-face {
+    position: relative;
+    transform: none !important;
+    backface-visibility: visible;
+    display: grid;
+  }
+
+  .cadence-card .card-back {
+    display: none;
+  }
+
+  .cadence-card.is-flipped .card-front {
+    display: none;
+  }
+
+  .cadence-card.is-flipped .card-back {
+    display: grid;
+  }
+
+  .cadence-card .card-surface {
+    transform: none !important;
+    opacity: 1 !important;
+  }
+
+  .orientation-icon.is-playing {
+    animation: none;
+  }
+
+  .cadence-card.is-flipped .orientation-icon {
+    opacity: 1;
+    transform: none;
+  }
 }
 .officer-details {
   margin-top: 3rem;


### PR DESCRIPTION
## Summary
- Refresh apply cadence copy and card markup to match the new week messaging while adding accessible labels.
- Rebuild cadence card styling with rounded surfaces, animated edge glow and spark, parallax content, a movie-night clapboard, and reduced-motion fallbacks.
- Add JavaScript to manage flip timing, pointer-driven parallax, touch toggles, keyboard/Esc parity, and the clapboard easter egg.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d20a659f78832da8daf526dd1e751c