### PR TITLE
Implement comet border animation for cadence cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -581,7 +581,6 @@ footer.site-footer {
   --flip-easing: cubic-bezier(0.55, 0, 0.55, 0.2);
   --layer-shift-x: 0px;
   --layer-shift-y: 0px;
-  --edge-angle: 0deg;
   isolation: isolate;
   display: block;
   padding: 0;
@@ -618,17 +617,12 @@ footer.site-footer {
   inset: -1px;
   border-radius: calc(var(--card-radius) + 1px);
   padding: 1px;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(195, 239, 255, 0.65) 0%, rgba(195, 239, 255, 0.12) 55%, transparent 75%) 50% 0%/9px 9px
-      no-repeat,
-    conic-gradient(from 0deg, transparent 0deg, rgba(56, 189, 248, 0.55) 22deg, rgba(56, 189, 248, 0.08) 74deg, transparent 120deg);
+  background: linear-gradient(130deg, rgba(148, 197, 255, 0.24), rgba(56, 189, 248, 0.08));
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   mask-composite: exclude;
   opacity: 0;
-  transform-origin: center;
-  transform: rotate(var(--edge-angle, 0deg));
   transition: opacity 0.35s ease;
   pointer-events: none;
   z-index: 3;
@@ -666,6 +660,69 @@ footer.site-footer {
   transition: opacity 0.5s cubic-bezier(0.33, 1, 0.68, 1);
   pointer-events: none;
   z-index: 1;
+}
+
+.cadence-orbit {
+  --orbit-alpha: 0;
+  --orbit-energy: 1;
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: var(--orbit-alpha, 0);
+  transition: opacity 0.38s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.cadence-orbit__trail,
+.cadence-orbit__head {
+  position: absolute;
+  top: 0;
+  left: 0;
+  offset-path: var(--orbit-path);
+  offset-distance: 0%;
+  offset-rotate: auto;
+  will-change: offset-distance, transform, opacity;
+}
+
+.cadence-orbit__trail {
+  width: clamp(42px, 9vw, 72px);
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(56, 189, 248, 0) 0%,
+    rgba(99, 226, 255, 0.15) 28%,
+    rgba(226, 250, 255, 0.7) 72%,
+    rgba(255, 255, 255, 0.95) 100%
+  );
+  filter: drop-shadow(0 0 calc(12px + 18px * var(--orbit-energy, 1)) rgba(56, 189, 248, 0.45));
+  transform: translate(-100%, -50%);
+  opacity: 0.9;
+}
+
+.cadence-orbit__head {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, #ffffff 0%, #e0f2ff 40%, rgba(165, 243, 252, 0.85) 65%, rgba(56, 189, 248, 0.1) 100%);
+  box-shadow:
+    0 0 calc(12px + 14px * var(--orbit-energy, 1)) rgba(56, 189, 248, 0.8),
+    0 0 calc(24px + 18px * var(--orbit-energy, 1)) rgba(14, 165, 233, 0.45),
+    0 0 calc(48px + 24px * var(--orbit-energy, 1)) rgba(56, 189, 248, 0.35);
+  transform: translate(-50%, -50%);
+}
+
+@supports not (offset-path: path("M 0 0 L 1 1")) {
+  .cadence-orbit {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cadence-orbit {
+    display: none;
+  }
 }
 
 .cadence-card .card-face {
@@ -808,7 +865,6 @@ footer.site-footer {
 
 .cadence-card.is-engaged::before {
   opacity: 1;
-  animation: edgeOrbit 2.6s linear infinite;
 }
 
 .cadence-card.is-engaged::after,
@@ -829,15 +885,6 @@ footer.site-footer {
 
 .cadence-card:focus-visible .card-face {
   border-color: rgba(56, 189, 248, 0.6);
-}
-
-@keyframes edgeOrbit {
-  0% {
-    transform: rotate(var(--edge-angle, 0deg));
-  }
-  100% {
-    transform: rotate(calc(var(--edge-angle, 0deg) + 360deg));
-  }
 }
 
 @keyframes clapboardTick {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -67,6 +67,249 @@
     const cards = Array.from(document.querySelectorAll("[data-card]"));
     if (!cards.length) return;
 
+    const ORBIT_LOOP_DURATION = 2600;
+    const ORBIT_TRAIL_FRACTION = 0.09;
+
+    const createRoundedPath = (width, height, radius) => {
+      const r = Math.max(Math.min(radius, Math.min(width, height) / 2), 0);
+      const w = Math.max(width, 0);
+      const h = Math.max(height, 0);
+      return [
+        `M ${r} 0`,
+        `H ${w - r}`,
+        `Q ${w} 0 ${w} ${r}`,
+        `V ${h - r}`,
+        `Q ${w} ${h} ${w - r} ${h}`,
+        `H ${r}`,
+        `Q 0 ${h} 0 ${h - r}`,
+        `V ${r}`,
+        `Q 0 0 ${r} 0`,
+        "Z",
+      ].join(" ");
+    };
+
+    const computeSegmentStops = (width, height, radius) => {
+      const r = Math.max(Math.min(radius, Math.min(width, height) / 2), 0);
+      const horizontal = Math.max(width - 2 * r, 0);
+      const vertical = Math.max(height - 2 * r, 0);
+      const arcLength = (Math.PI / 2) * r;
+      const segments = [
+        horizontal,
+        arcLength,
+        vertical,
+        arcLength,
+        horizontal,
+        arcLength,
+        vertical,
+        arcLength,
+      ];
+      const total = segments.reduce((sum, value) => sum + value, 0);
+      if (!total) return [];
+      let running = 0;
+      return segments.map((segment) => {
+        running += segment;
+        return running / total;
+      });
+    };
+
+    class OrbitController {
+      constructor(card) {
+        this.card = card;
+        this.duration = ORBIT_LOOP_DURATION;
+        this.trailOffset = ORBIT_TRAIL_FRACTION;
+        this.orbit = document.createElement("span");
+        this.orbit.className = "cadence-orbit";
+        this.trail = document.createElement("span");
+        this.trail.className = "cadence-orbit__trail";
+        this.head = document.createElement("span");
+        this.head.className = "cadence-orbit__head";
+        this.orbit.append(this.trail, this.head);
+        this.card.appendChild(this.orbit);
+
+        this.progress = 0;
+        this.frame = null;
+        this.lastTimestamp = null;
+        this.pendingFade = null;
+        this.segmentStops = [];
+        this.alpha = 0;
+        this.engaged = false;
+        this.reduceMotion = false;
+
+        this.tick = this.tick.bind(this);
+        this.updateGeometry = this.updateGeometry.bind(this);
+
+        this.updateGeometry();
+        this.updateOrbitDistance();
+
+        if (typeof ResizeObserver === "function") {
+          this.resizeObserver = new ResizeObserver(() => this.updateGeometry());
+          this.resizeObserver.observe(this.card);
+        } else {
+          window.addEventListener("resize", this.updateGeometry);
+        }
+      }
+
+      updateGeometry() {
+        const rect = this.card.getBoundingClientRect();
+        const width = rect.width;
+        const height = rect.height;
+        if (!width || !height) return;
+
+        let radius = 0;
+        const face = this.card.querySelector(".card-face");
+        if (face) {
+          const style = window.getComputedStyle(face);
+          const radiusValue = style.borderTopLeftRadius;
+          const parsed = parseFloat(radiusValue);
+          if (!Number.isNaN(parsed)) {
+            radius = parsed;
+          }
+        }
+
+        if (!radius) {
+          radius = Math.min(width, height) * 0.12;
+        }
+
+        radius = Math.min(radius, width / 2, height / 2);
+
+        const pathData = createRoundedPath(width, height, radius);
+        this.orbit.style.setProperty("--orbit-path", `path('${pathData}')`);
+        this.segmentStops = computeSegmentStops(width, height, radius);
+        this.updateOrbitDistance();
+      }
+
+      updateOrbitDistance() {
+        const normalized = ((this.progress % 1) + 1) % 1;
+        const headDistance = `${(normalized * 100).toFixed(3)}%`;
+        const tailNormalized = ((normalized - this.trailOffset) % 1 + 1) % 1;
+        const trailDistance = `${(tailNormalized * 100).toFixed(3)}%`;
+
+        this.head.style.setProperty("offset-distance", headDistance);
+        this.trail.style.setProperty("offset-distance", trailDistance);
+
+        const energy = 0.85 + 0.15 * Math.sin(normalized * Math.PI * 2);
+        this.orbit.style.setProperty("--orbit-energy", energy.toFixed(3));
+      }
+
+      setAlpha(value) {
+        const clamped = Math.max(0, Math.min(1, value));
+        if (Math.abs(clamped - this.alpha) < 0.001) return;
+        this.alpha = clamped;
+        this.orbit.style.setProperty("--orbit-alpha", clamped.toFixed(3));
+      }
+
+      ensureAnimation() {
+        if (this.reduceMotion) return;
+        if (this.frame !== null) return;
+        this.lastTimestamp = null;
+        this.frame = requestAnimationFrame(this.tick);
+      }
+
+      scheduleFade() {
+        if (this.alpha <= 0.001) {
+          this.setAlpha(0);
+          return;
+        }
+
+        const normalized = ((this.progress % 1) + 1) % 1;
+        let target = normalized + 0.25;
+
+        if (this.segmentStops && this.segmentStops.length) {
+          const nextStop = this.segmentStops.find((stop) => stop > normalized + 0.0001);
+          if (typeof nextStop === "number") {
+            target = nextStop;
+          } else {
+            target = this.segmentStops[0] + 1;
+          }
+        }
+
+        const base = this.progress - normalized;
+        this.pendingFade = { trigger: base + target };
+      }
+
+      updateEngagedState(isEngaged) {
+        this.engaged = isEngaged;
+        if (this.reduceMotion) {
+          if (!isEngaged) {
+            this.setAlpha(0);
+          }
+          return;
+        }
+
+        if (isEngaged) {
+          this.pendingFade = null;
+          this.setAlpha(1);
+          this.ensureAnimation();
+        } else {
+          this.scheduleFade();
+          this.ensureAnimation();
+        }
+      }
+
+      tick(timestamp) {
+        if (this.reduceMotion) {
+          if (this.frame !== null) {
+            cancelAnimationFrame(this.frame);
+            this.frame = null;
+          }
+          this.lastTimestamp = null;
+          return;
+        }
+
+        if (this.frame === null) {
+          return;
+        }
+
+        if (!this.lastTimestamp) {
+          this.lastTimestamp = timestamp;
+        }
+
+        const delta = timestamp - this.lastTimestamp;
+        this.lastTimestamp = timestamp;
+
+        if (delta > 0) {
+          this.progress += delta / this.duration;
+        }
+
+        this.updateOrbitDistance();
+
+        if (this.pendingFade && this.progress >= this.pendingFade.trigger) {
+          this.pendingFade = null;
+          this.setAlpha(0);
+        }
+
+        const shouldContinue = this.engaged || this.pendingFade || this.alpha > 0.001;
+
+        if (shouldContinue) {
+          this.frame = requestAnimationFrame(this.tick);
+        } else {
+          this.frame = null;
+          this.lastTimestamp = null;
+          this.progress = ((this.progress % 1) + 1) % 1;
+        }
+      }
+
+      setReducedMotion(value) {
+        if (this.reduceMotion === value) return;
+        this.reduceMotion = value;
+
+        if (value) {
+          this.pendingFade = null;
+          this.setAlpha(0);
+          if (this.frame !== null) {
+            cancelAnimationFrame(this.frame);
+            this.frame = null;
+          }
+          this.lastTimestamp = null;
+        } else if (this.engaged) {
+          this.setAlpha(1);
+          this.ensureAnimation();
+        }
+      }
+    }
+
+    const orbitControllers = new WeakMap();
+
     const FLIP_IN_DURATION = 0.6;
     const FLIP_OUT_DURATION = 0.28;
     const FLIP_IN_EASING = "cubic-bezier(0.16, 1, 0.3, 1)";
@@ -90,6 +333,10 @@
       const { animate = true, force = false } = options;
       const isCurrentlyFlipped = card.classList.contains("is-flipped");
       if (isCurrentlyFlipped === flipped && !force) {
+        const existingOrbit = orbitControllers.get(card);
+        if (existingOrbit) {
+          existingOrbit.updateEngagedState(card.classList.contains("is-engaged"));
+        }
         updateAria(card, flipped);
         return;
       }
@@ -104,6 +351,10 @@
 
       card.classList.toggle("is-flipped", flipped);
       card.classList.toggle("is-engaged", flipped || card === document.activeElement);
+      const orbit = orbitControllers.get(card);
+      if (orbit) {
+        orbit.updateEngagedState(card.classList.contains("is-engaged"));
+      }
       updateAria(card, flipped);
 
       if (!flipped) {
@@ -149,19 +400,17 @@
 
       card.style.setProperty("--layer-shift-x", `${shiftX.toFixed(2)}px`);
       card.style.setProperty("--layer-shift-y", `${shiftY.toFixed(2)}px`);
-
-      if (Math.abs(normalizedX) < 0.01 && Math.abs(normalizedY) < 0.01) {
-        card.style.setProperty("--edge-angle", "0deg");
-      } else {
-        const angle = Math.atan2(normalizedY, normalizedX);
-        let angleDeg = angle * (180 / Math.PI) + 90;
-        if (angleDeg < 0) angleDeg += 360;
-        card.style.setProperty("--edge-angle", `${angleDeg}deg`);
-      }
     };
 
     const handleMotionChange = () => {
       reduceMotion = motionQuery.matches;
+      cards.forEach((card) => {
+        const orbit = orbitControllers.get(card);
+        if (orbit) {
+          orbit.setReducedMotion(reduceMotion);
+          orbit.updateEngagedState(card.classList.contains("is-engaged"));
+        }
+      });
       if (reduceMotion) {
         cards.forEach((card) => {
           setFlipState(card, false, { animate: false, force: true });
@@ -181,6 +430,11 @@
     cards.forEach((card, index) => {
       card.style.setProperty("--card-reveal-delay", `${index * 60}ms`);
       updateAria(card, false);
+
+      const orbit = new OrbitController(card);
+      orbitControllers.set(card, orbit);
+      orbit.setReducedMotion(reduceMotion);
+      orbit.updateEngagedState(card.classList.contains("is-engaged"));
 
       card.addEventListener("pointerenter", (event) => {
         if (reduceMotion) return;
@@ -219,11 +473,13 @@
 
       card.addEventListener("focus", () => {
         card.classList.add("is-engaged");
+        orbit.updateEngagedState(true);
       });
 
       card.addEventListener("blur", () => {
         if (!card.classList.contains("is-flipped")) {
           card.classList.remove("is-engaged");
+          orbit.updateEngagedState(false);
         }
       });
 


### PR DESCRIPTION
## Summary
- replace the conic-gradient border highlight with a path-following comet glow for cadence cards
- add a motion-path driven OrbitController that animates a head and trail along the card perimeter and respects hover/focus state
- refine card interaction logic to drive the new orbit animation and remove the legacy edge-angle handling

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d210f48980832dbefc9a91ac7c18f8