### PR TITLE
Polish leadership hover overlay and blur

### DIFF
--- a/about.html
+++ b/about.html
@@ -187,7 +187,7 @@
             <div class="team-grid team-grid-leadership">
               <!-- Leadership cards use an overlay treatment to create the required fade without introducing a new component. -->
               <article class="team-card team-card-leader" tabindex="0">
-                <div class="team-image">
+                <div class="team-image" style="--portrait: url('assets/Images/President.png');">
                   <img src="assets/Images/President.png" alt="Portrait of Aryan Sharma, President in Charge of The Cloud Network" />
                   <div class="team-card-info">
                     <p class="team-role">President in Charge</p>
@@ -196,7 +196,7 @@
                 </div>
               </article>
               <article class="team-card team-card-leader" tabindex="0">
-                <div class="team-image">
+                <div class="team-image" style="--portrait: url('assets/Images/Treasurer.png');">
                   <img src="assets/Images/Treasurer.png" alt="Portrait of Pratham Patil, Treasurer of The Cloud Network" />
                   <div class="team-card-info">
                     <p class="team-role">Treasurer</p>
@@ -205,7 +205,7 @@
                 </div>
               </article>
               <article class="team-card team-card-leader" tabindex="0">
-                <div class="team-image">
+                <div class="team-image" style="--portrait: url('assets/Images/Vice-President.png');">
                   <img src="assets/Images/Vice-President.png" alt="Portrait of Will Greenwood, Vice President of The Cloud Network" />
                   <div class="team-card-info">
                     <p class="team-role">Vice President</p>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1125,31 +1125,11 @@ footer.site-footer {
   flex-direction: column;
   justify-content: flex-end;
   gap: 0.45rem;
-  z-index: 2;
+  z-index: 3;
   background: transparent;
   isolation: isolate;
   transform: translateY(0);
-  transition: transform 0.45s cubic-bezier(0.25, 0.8, 0.25, 1);
-}
-
-.team-card-leader .team-card-info::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  /* Premium continuous fade that keeps officer details anchored within a high-contrast zone. */
-  background: linear-gradient(
-    to top,
-    rgba(2, 6, 23, 0.92) 0%,
-    rgba(2, 6, 23, 0.86) 18%,
-    rgba(2, 6, 23, 0.72) 36%,
-    rgba(2, 6, 23, 0.52) 54%,
-    rgba(2, 6, 23, 0.28) 72%,
-    rgba(2, 6, 23, 0.12) 86%,
-    rgba(2, 6, 23, 0) 100%
-  );
-  opacity: 0.98;
-  transition: opacity 0.45s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
 .team-card-leader .team-role,
@@ -1179,19 +1159,140 @@ footer.site-footer {
   --leader-lift: -10px;
   --leader-scale: 1.015;
   --leader-shadow: 0 34px 70px -34px rgba(56, 189, 248, 0.82);
-  transition: transform 0.45s cubic-bezier(0.25, 0.8, 0.25, 1),
-    box-shadow 0.45s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
+    box-shadow 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
 .team-card-leader .team-image,
 .team-card-leader .team-card-info,
 .team-card-leader .team-image img {
-  transition: transform 0.45s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.team-card-leader .team-image {
+  will-change: transform;
+  transform-origin: center bottom;
+}
+
+.team-card-leader .team-image::before {
+  content: "";
+  position: absolute;
+  left: -8%;
+  right: -8%;
+  top: 54%;
+  bottom: -24%;
+  pointer-events: none;
+  z-index: 1;
+  background-image: var(--portrait, none);
+  background-size: cover;
+  background-position: center bottom;
+  background-repeat: no-repeat;
+  filter: blur(clamp(28px, 4vw, 46px));
+  transform-origin: center top;
+  transform: translateY(6%) scale(1.12);
+  opacity: 0.92;
+  mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.95) 0%,
+    rgba(0, 0, 0, 0.7) 28%,
+    rgba(0, 0, 0, 0.38) 58%,
+    rgba(0, 0, 0, 0) 88%
+  );
+  -webkit-mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.95) 0%,
+    rgba(0, 0, 0, 0.7) 28%,
+    rgba(0, 0, 0, 0.38) 58%,
+    rgba(0, 0, 0, 0) 88%
+  );
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  transition: opacity 0.42s cubic-bezier(0.25, 0.8, 0.25, 1),
+    transform 0.42s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.team-card-leader .team-image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  background: linear-gradient(
+    to top,
+    rgba(2, 6, 23, 0.95) 0%,
+    rgba(2, 6, 23, 0.9) 20%,
+    rgba(2, 6, 23, 0.76) 38%,
+    rgba(2, 6, 23, 0.52) 58%,
+    rgba(2, 6, 23, 0.28) 76%,
+    rgba(2, 6, 23, 0) 100%
+  );
+  backdrop-filter: blur(clamp(18px, 4vw, 32px));
+  -webkit-backdrop-filter: blur(clamp(18px, 4vw, 32px));
+  mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 1) 0%,
+    rgba(0, 0, 0, 0.95) 12%,
+    rgba(0, 0, 0, 0.78) 28%,
+    rgba(0, 0, 0, 0.5) 46%,
+    rgba(0, 0, 0, 0.24) 70%,
+    rgba(0, 0, 0, 0) 92%
+  );
+  -webkit-mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 1) 0%,
+    rgba(0, 0, 0, 0.95) 12%,
+    rgba(0, 0, 0, 0.78) 28%,
+    rgba(0, 0, 0, 0.5) 46%,
+    rgba(0, 0, 0, 0.24) 70%,
+    rgba(0, 0, 0, 0) 92%
+  );
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  opacity: 0.98;
+  transition: opacity 0.42s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.team-card-leader:is(:hover, :focus-visible) .team-image::before {
+  opacity: 0.98;
+  transform: translateY(3%) scale(1.18);
+}
+
+.team-card-leader:is(:hover, :focus-visible) .team-image::after {
+  opacity: 1;
+}
+
+@supports not ((backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))) {
+  .team-card-leader .team-image::after {
+    background: linear-gradient(
+      to top,
+      rgba(2, 6, 23, 0.9) 0%,
+      rgba(2, 6, 23, 0.82) 18%,
+      rgba(2, 6, 23, 0.62) 38%,
+      rgba(2, 6, 23, 0.4) 60%,
+      rgba(2, 6, 23, 0.18) 80%,
+      rgba(2, 6, 23, 0) 92%
+    );
+  }
+}
+
+@media (max-width: 720px) {
+  .team-card-leader .team-image::before {
+    top: 58%;
+    bottom: -26%;
+    transform: translateY(8%) scale(1.16);
+  }
+}
+
+@media (max-width: 520px) {
+  .team-card-leader .team-image::before {
+    top: 62%;
+    bottom: -30%;
+  }
 }
 
 .team-card-leader .team-role,
 .team-card-leader .team-name {
-  transition: transform 0.45s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
 .team-card-leader:is(:hover, :focus-visible) {
@@ -1204,14 +1305,10 @@ footer.site-footer {
 }
 
 .team-card-leader:is(:hover, :focus-visible) .team-card-info {
-  transform: translateY(-4px);
+  transform: translateY(0);
 }
 
-.team-card-leader:is(:hover, :focus-visible) .team-card-info::before {
-  opacity: 1;
-}
-
-.team-card-leader:is(:hover, :focus-visible) .team-image img {
+.team-card-leader:is(:hover, :focus-visible) .team-image {
   transform: translateY(-6px) scale(1.05);
 }
 


### PR DESCRIPTION
## Summary
- anchor the leadership hover treatment to the shared image wrapper so the gradient overlay and copy move as one surface
- add a portrait-driven bottom blur and updated gradient overlay so the fade matches the reference photo
- tune the blur mask for smaller breakpoints to keep the reveal seamless on mobile

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d21e582398832da878a7ebe9590f10