### PR TITLE
Remove blur overlays from team portraits

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1187,7 +1187,6 @@ footer.site-footer {
   background-size: cover;
   background-position: center bottom;
   background-repeat: no-repeat;
-  filter: blur(clamp(28px, 4vw, 46px));
   transform-origin: center top;
   transform: translateY(6%) scale(1.12);
   opacity: 0.92;
@@ -1226,8 +1225,6 @@ footer.site-footer {
     rgba(2, 6, 23, 0.28) 76%,
     rgba(2, 6, 23, 0) 100%
   );
-  backdrop-filter: blur(clamp(18px, 4vw, 32px));
-  -webkit-backdrop-filter: blur(clamp(18px, 4vw, 32px));
   mask-image: linear-gradient(
     to top,
     rgba(0, 0, 0, 1) 0%,
@@ -1336,9 +1333,6 @@ footer.site-footer {
   inset: 0;
   pointer-events: none;
   z-index: 1;
-  /* Backdrop blur is shaped with a vertical mask so the strength eases from strong at the base to none by ~38%. */
-  backdrop-filter: blur(clamp(20px, 5vw, 36px));
-  -webkit-backdrop-filter: blur(clamp(20px, 5vw, 36px));
   background: linear-gradient(
     to top,
     rgba(2, 6, 23, 0.4) 0%,


### PR DESCRIPTION
## Summary
- remove the blur treatment from the leadership portrait overlay so the photos stay sharp
- drop the backdrop blur on all team cards to keep member images crisp

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d223a73abc832d9a470797125f1632