### PR TITLE
Implement PDF callout modal and navigation updates

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,7 +24,7 @@
           <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About Us</a></li>
-            <li><a href="storyline.html">Storyline</a></li>
+            <!-- <li><a href="storyline.html">Storyline</a></li> -->
             <li><a href="apply.html">Apply</a></li>
           </ul>
         </nav>

--- a/apply.html
+++ b/apply.html
@@ -24,7 +24,7 @@
           <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About Us</a></li>
-            <li><a href="storyline.html">Storyline</a></li>
+            <!-- <li><a href="storyline.html">Storyline</a></li> -->
             <li><a href="apply.html">Apply</a></li>
           </ul>
         </nav>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -469,6 +469,149 @@ textarea {
   box-shadow: var(--shadow-card);
 }
 
+.callout-centered {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+  padding: 2.75rem 3rem;
+  background: linear-gradient(145deg, rgba(56, 189, 248, 0.28), rgba(15, 23, 42, 0.92));
+  border: 1px solid rgba(148, 197, 242, 0.35);
+  box-shadow: 0 30px 70px rgba(8, 47, 73, 0.45);
+}
+
+.callout-centered .section-title {
+  margin-bottom: 0;
+  font-size: clamp(1.5rem, 2.75vw, 2.1rem);
+}
+
+.callout-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.callout-centered p {
+  margin: 0;
+  color: var(--text-muted);
+  max-width: 540px;
+}
+
+.callout-actions .button {
+  min-width: 180px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.pdf-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  background: rgba(2, 6, 23, 0.82);
+  backdrop-filter: blur(14px);
+  z-index: 9999;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+.pdf-overlay.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.pdf-modal {
+  max-width: min(900px, 100%);
+  width: 100%;
+  border-radius: 1.1rem;
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.95), rgba(8, 47, 73, 0.92));
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  box-shadow: 0 40px 80px rgba(2, 6, 23, 0.7);
+  overflow: hidden;
+}
+
+.pdf-frame-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.pdf-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.75rem;
+  border-bottom: 1px solid rgba(56, 189, 248, 0.25);
+}
+
+.pdf-modal-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pdf-close {
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--text-primary);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  border-radius: 999px;
+  width: 2rem;
+  height: 2rem;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: var(--transition-base);
+}
+
+.pdf-close:hover,
+.pdf-close:focus {
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--accent);
+}
+
+.pdf-poster {
+  padding: 1.75rem;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.35), transparent 55%),
+    linear-gradient(145deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.95));
+}
+
+.pdf-poster iframe {
+  width: 100%;
+  min-height: clamp(420px, 60vh, 640px);
+  border: none;
+  border-radius: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 197, 242, 0.4), 0 25px 45px rgba(15, 23, 42, 0.45);
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.pdf-overlay[hidden] {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .callout-centered {
+    padding: 2.25rem 1.75rem;
+  }
+
+  .pdf-modal {
+    border-radius: 0.85rem;
+  }
+
+  .pdf-modal-header {
+    padding: 1rem 1.25rem;
+  }
+
+  .pdf-poster {
+    padding: 1.25rem;
+  }
+}
+
 .callout h3 {
   margin-top: 0;
   font-size: 1.4rem;

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About Us</a></li>
-            <li><a href="storyline.html">Storyline</a></li>
+            <!-- <li><a href="storyline.html">Storyline</a></li> -->
             <li><a href="apply.html">Apply</a></li>
           </ul>
         </nav>
@@ -53,8 +53,8 @@
               Network is our space to explore, launch, and celebrate ambitious ideas together.
             </p>
             <div class="hero-actions" data-animate>
-              <a class="button" href="storyline.html">Explore the narrative</a>
-              <a class="button secondary" href="apply.html">Join the network</a>
+              <a class="button" href="assets/pdf/callout.pdf" data-pdf-trigger>Explore the narrative</a>
+              <a class="button secondary" href="assets/pdf/callout.pdf" data-pdf-trigger>Join the network</a>
             </div>
           </div>
           <div class="hero-visual" aria-hidden="true">
@@ -89,7 +89,7 @@
                 curiosity, and intention.
               </p>
             </div>
-            <a class="button secondary" href="storyline.html" data-animate>Read the full story</a>
+            <a class="button secondary" href="storyline.html" data-animate style="display: none">Read the full story</a>
           </div>
 
           <div class="storyline-grid">
@@ -110,37 +110,16 @@
         <div class="section-divider bottom" aria-hidden="true"></div>
       </section>
 
-      <section class="section" aria-labelledby="section-experience">
-        <div class="wrapper split-layout">
-          <article class="offset-panel" data-animate>
-            <h2 id="section-experience" class="section-title">What the experience feels like</h2>
-            <p class="text-muted">
-              The Cloud Network is part studio, part lab, and part stage. We host intentional sprints, curated sessions,
-              and late-night build rituals that push concepts into tangible prototypes.
-            </p>
-            <div class="metrics-grid" style="margin-top: 2.25rem">
-              <div class="metric-card" data-animate>
-                <strong>8</strong>
-                <span>Core builders</span>
-              </div>
-              <div class="metric-card" data-animate>
-                <strong>4</strong>
-                <span>Active projects</span>
-              </div>
-              <div class="metric-card" data-animate>
-                <strong>12</strong>
-                <span>Partner nodes</span>
-              </div>
-            </div>
-          </article>
-          <aside class="callout" data-animate>
-            <h3>Ready to plug into the network?</h3>
+      <section class="section" aria-labelledby="section-ready">
+        <div class="wrapper">
+          <aside class="callout callout-centered" data-animate>
+            <h2 id="section-ready" class="section-title">Ready to plug into the network?</h2>
             <p>
               Applications open this semester. We review interest forms weekly and invite a select crew for interviews and
               build sessions.
             </p>
-            <div style="margin-top: 1.75rem">
-              <a class="button" href="apply.html">Start your application</a>
+            <div class="callout-actions">
+              <a class="button" href="assets/pdf/callout.pdf" data-pdf-trigger>Learn How</a>
             </div>
           </aside>
         </div>
@@ -157,6 +136,26 @@
         </nav>
       </div>
     </footer>
+
+    <div class="pdf-overlay" data-pdf-overlay data-pdf-src="assets/pdf/callout.pdf" hidden>
+      <div class="pdf-modal" role="dialog" aria-modal="true" aria-labelledby="pdf-modal-title">
+        <div class="pdf-frame-wrapper">
+          <header class="pdf-modal-header">
+            <h2 id="pdf-modal-title">Callout Details</h2>
+            <button type="button" class="pdf-close" data-pdf-close aria-label="Close dialog">×</button>
+          </header>
+          <div class="pdf-poster">
+            <iframe
+              src=""
+              title="Callout information"
+              data-pdf-frame
+              loading="lazy"
+              aria-label="Embedded callout details PDF"
+            ></iframe>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();

--- a/storyline.html
+++ b/storyline.html
@@ -24,7 +24,7 @@
           <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About Us</a></li>
-            <li><a href="storyline.html">Storyline</a></li>
+            <!-- <li><a href="storyline.html">Storyline</a></li> -->
             <li><a href="apply.html">Apply</a></li>
           </ul>
         </nav>


### PR DESCRIPTION
## Summary
- remove the experience metrics section and center the "Ready to plug into the network" callout with refreshed styling
- add a reusable PDF modal that opens the callout document from the hero, callout, and other targeted buttons
- hide the "Read the full story" CTA and temporarily comment Storyline out of the global navigation

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5aeada934832da7e74bf821305242