### PR TITLE
Add Blaise Moody to marketing team grid

### DIFF
--- a/about.html
+++ b/about.html
@@ -293,6 +293,15 @@
                 <div class="team-grid team-grid-members">
                   <article class="team-card" tabindex="0">
                     <div class="team-image">
+                      <img src="assets/Images/placeholder-profile.svg" alt="Placeholder portrait representing Blaise Moody, Head of Animations" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Head of Animations</p>
+                      <p class="team-name">Blaise Moody</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
                       <img src="assets/Images/AindriSingh.png" alt="Portrait of Aindri Singh, Campaign Director" />
                     </div>
                     <div class="team-card-body">

--- a/assets/Images/placeholder-profile.svg
+++ b/assets/Images/placeholder-profile.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Abstract placeholder portrait</title>
+  <desc id="desc">A simple gradient circle representing a placeholder profile portrait.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#22d3ee" stop-opacity="0.9" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="24" fill="#0f172a" />
+  <circle cx="80" cy="60" r="32" fill="url(#grad)" />
+  <path d="M32 144c8-32 32-52 48-52s40 20 48 52" fill="#1e293b" />
+</svg>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1506,6 +1506,12 @@ footer.site-footer {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+@media (min-width: 960px) {
+  .team-grid-members {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
 .team-subsections {
   display: grid;
   gap: 3rem;


### PR DESCRIPTION
## Summary
- add Blaise Moody to the marketing team grid with an accessible placeholder portrait
- align member grid columns to show four cards on large screens for consistent sizing
- include a reusable placeholder profile asset for future imagery updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf6ae5f5c832d824cf67d76647b95