### PR TITLE
Sync hero full stop animation with title visibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -54,7 +54,7 @@
             </div>
 
             <!-- Full stop divider (keeps visual parity with index/apply pages) -->
-            <span class="hero-fullstop" aria-hidden="true">.</span>
+            <span class="hero-fullstop" aria-hidden="true" data-animate>.</span>
             <p class="hero-subtitle" data-animate>
               The Cloud Network was born in a dorm room between late-night whiteboards and improvised prototypes. Today we
               are a collective shaping how stories, spaces, and systems connect across the university.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -22,7 +22,23 @@
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
+            // Add visible to the target
             entry.target.classList.add("visible");
+
+            // If the hero title becomes visible, immediately mark the full stop
+            // visible as well so the punctuation animates in perfect sync.
+            try {
+              if (entry.target.id === "hero-title") {
+                const fullstop = document.querySelector(".hero-fullstop[data-animate]");
+                if (fullstop) {
+                  fullstop.classList.add("visible");
+                  observer.unobserve(fullstop);
+                }
+              }
+            } catch (e) {
+              // swallow any unexpected errors to avoid breaking other observers
+            }
+
             observer.unobserve(entry.target);
           }
         });

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
               </span>
             </h1>
             <!-- Full stop divider: separate element so it doesn't flow with the rotating text -->
-            <span class="hero-fullstop" aria-hidden="true">.</span>
+            <span class="hero-fullstop" aria-hidden="true" data-animate>.</span>
 
             <p class="hero-subtitle" data-animate>
               We are students and creators prototyping new ways of connecting people, devices, and dreams. The Cloud


### PR DESCRIPTION
Added data-animate attribute to hero full stop elements in about.html and index.html. Updated main.js to animate the full stop in sync with the hero title by marking it visible when the title becomes visible. This improves the visual effect and maintains consistency across pages.