### PR TITLE
Implement apply page RSVP form

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -156,58 +156,95 @@
 
       <section class="section" aria-labelledby="application-form">
         <div class="wrapper split-layout">
-          <!--
           <article>
             <h2 id="application-form" class="section-title" data-animate>Application form</h2>
             <p class="text-muted" data-animate>
-              This is an interest form. We’ll follow up with next steps and a build challenge if it feels like a fit. All
-              fields are required so we can learn how you think and collaborate.
+              Share how we can reach you and what you’re studying. Required fields are marked and everything else is
+              optional context that helps us tailor the right Cloud Network experience.
             </p>
-            <form class="form-card" data-mock-submit data-animate>
+            <form class="form-card" action="/api/rsvp.php" method="POST" data-rsvp-form data-animate>
+              <div class="honeypot-field" aria-hidden="true">
+                <label for="apply-honey">Leave this field empty</label>
+                <input id="apply-honey" name="honey" type="text" tabindex="-1" autocomplete="off" data-honey />
+              </div>
               <div class="form-grid">
                 <div>
-                  <label for="name">Full name</label>
-                  <input id="name" name="name" type="text" placeholder="Jordan Rivera" required />
+                  <label for="full_name"
+                    >Full name<span aria-hidden="true" class="required-indicator">*</span
+                    ><span class="visually-hidden"> required</span></label
+                  >
+                  <input
+                    id="full_name"
+                    name="full_name"
+                    type="text"
+                    placeholder="Jordan Rivera"
+                    autocomplete="name"
+                    required
+                  />
                 </div>
                 <div>
-                  <label for="email">Email</label>
-                  <input id="email" name="email" type="email" placeholder="you@cloud.network" required />
+                  <label for="email"
+                    >Email<span aria-hidden="true" class="required-indicator">*</span
+                    ><span class="visually-hidden"> required</span></label
+                  >
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    placeholder="you@cloud.network"
+                    autocomplete="email"
+                    required
+                  />
                 </div>
                 <div>
-                  <label for="portfolio">Portfolio or project link</label>
-                  <input id="portfolio" name="portfolio" type="url" placeholder="https://" required />
+                  <label for="phone">Phone</label>
+                  <input
+                    id="phone"
+                    name="phone"
+                    type="tel"
+                    placeholder="(765) 123-4567"
+                    autocomplete="tel"
+                    inputmode="tel"
+                  />
                 </div>
                 <div>
-                  <label for="focus">Focus area</label>
-                  <select id="focus" name="focus" required>
-                    <option value="" disabled selected>Select one</option>
-                    <option value="systems">Systems &amp; engineering</option>
-                    <option value="design">Design &amp; interaction</option>
-                    <option value="media">Media &amp; storytelling</option>
-                    <option value="ops">Operations &amp; partnerships</option>
-                  </select>
+                  <label for="major">Major</label>
+                  <input id="major" name="major" type="text" placeholder="Computer Engineering" autocomplete="organization" />
+                </div>
+                <div>
+                  <label for="grad_year">Graduation year</label>
+                  <input
+                    id="grad_year"
+                    name="grad_year"
+                    type="text"
+                    placeholder="2026"
+                    inputmode="numeric"
+                    pattern="[0-9]{4}"
+                    title="Enter a four-digit year, e.g., 2026."
+                  />
                 </div>
               </div>
               <div style="margin-top: 1.5rem">
-                <label for="why">What are you excited to build with us?</label>
-                <textarea id="why" name="why" placeholder="Sketch your narrative..." required></textarea>
-              </div>
-              <div style="margin-top: 1.5rem">
-                <label for="availability">Availability</label>
+                <label for="notes">Anything else we should know?</label>
                 <textarea
-                  id="availability"
-                  name="availability"
-                  placeholder="Let us know your semester schedule or constraints."
-                  required
+                  id="notes"
+                  name="notes"
+                  placeholder="Goals, clubs you’re part of, or projects you’d love to build."
+                  rows="5"
                 ></textarea>
               </div>
-              <div style="margin-top: 2rem; display: flex; align-items: center; gap: 1.5rem">
-                <button class="button" type="submit">Submit Application</button>
-                <span class="text-muted" data-form-feedback aria-live="polite"></span>
+              <div class="form-consent">
+                <input id="consent" name="consent" type="checkbox" value="yes" required />
+                <label for="consent">
+                  I agree to be contacted about Cloud Network Purdue events and opportunities.
+                </label>
+              </div>
+              <div class="form-actions">
+                <button class="button" type="submit" data-submit-button>Submit RSVP</button>
+                <div class="form-status" data-form-feedback aria-live="polite" role="status"></div>
               </div>
             </form>
           </article>
-          -->
           <!--
           <aside class="layer-card" data-animate>
             <h3 style="margin-top: 0">What happens next</h3>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -37,6 +37,19 @@ body {
   flex-direction: column;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -640,6 +653,163 @@ select:focus {
 textarea {
   resize: vertical;
   min-height: 160px;
+}
+
+.required-indicator {
+  color: var(--accent);
+  margin-left: 0.25rem;
+}
+
+.honeypot-field {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.form-consent {
+  margin-top: 1.75rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem 1rem;
+  align-items: flex-start;
+}
+
+.form-consent label {
+  margin: 0;
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.form-consent input[type="checkbox"] {
+  margin-top: 0.2rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.7);
+  appearance: none;
+  display: grid;
+  place-items: center;
+  transition: border-color 0.3s ease, background-color 0.3s ease;
+}
+
+.form-consent input[type="checkbox"]::after {
+  content: "";
+  width: 0.45rem;
+  height: 0.75rem;
+  border: solid transparent;
+  border-width: 0 0.2rem 0.2rem 0;
+  transform: rotate(45deg) scale(0);
+  transition: transform 0.25s ease;
+}
+
+.form-consent input[type="checkbox"]:checked {
+  border-color: var(--accent);
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.form-consent input[type="checkbox"]:checked::after {
+  border-color: var(--accent);
+  transform: rotate(45deg) scale(1);
+}
+
+.form-actions {
+  margin-top: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.form-status {
+  min-height: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.form-status.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.form-status__icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  border: 2px solid currentColor;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  flex-shrink: 0;
+  transform: scale(0.6);
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.form-status.is-visible .form-status__icon {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.form-status__text {
+  display: inline-block;
+  max-width: 32ch;
+}
+
+.form-status--success {
+  color: #34d399;
+}
+
+.form-status--success .form-status__icon::after {
+  content: "";
+  position: absolute;
+  width: 0.45rem;
+  height: 0.9rem;
+  border: solid currentColor;
+  border-width: 0 0.2rem 0.2rem 0;
+  transform: rotate(45deg);
+  top: 0.2rem;
+}
+
+.form-status--error {
+  color: #f87171;
+}
+
+.form-status--error .form-status__icon::before,
+.form-status--error .form-status__icon::after {
+  content: "";
+  position: absolute;
+  width: 0.85rem;
+  height: 0.12rem;
+  background-color: currentColor;
+  border-radius: 999px;
+}
+
+.form-status--error .form-status__icon::before {
+  transform: rotate(45deg);
+}
+
+.form-status--error .form-status__icon::after {
+  transform: rotate(-45deg);
 }
 
 .callout {


### PR DESCRIPTION
## Summary
- replace the mocked Apply page contact form with a live RSVP form that posts to `/api/rsvp.php` and aligns the input names with the backend contract
- add client-side validation, honeypot handling, and progressive enhancement fetch submission with success and error messaging
- update form styling to support consent, status messaging, and a success animation while keeping the existing look and feel

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dcd533893c832dae91a645c3191633