### PR TITLE
Ensure RSVP submissions use POST

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -458,12 +458,14 @@
       const formData = new FormData(form);
 
       try {
-        const response = await fetch(form.getAttribute("action") || "/api/rsvp.php", {
-          method: (form.getAttribute("method") || "POST").toUpperCase(),
+        const endpoint = form.getAttribute("action") || "/api/rsvp.php";
+        const response = await fetch(endpoint, {
+          method: "POST",
           body: formData,
           headers: {
             Accept: "application/json",
           },
+          credentials: "same-origin",
         });
 
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- ensure the RSVP form JS explicitly posts FormData to the backend endpoint
- include same-origin credentials so the native POST mirrors the browser form submission

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcdc355ab0832db920a87e32b2a78b