### PR TITLE
Refine apply form consent toggle

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -263,38 +263,25 @@
                   rows="5"
                 ></textarea>
               </div>
-              <div class="form-consent" data-consent-toggle>
-                <input type="hidden" name="consent" value="yes" data-consent-input />
-                <button
-                  class="consent-toggle"
-                  type="button"
-                  data-consent-button
-                  aria-pressed="true"
-                  aria-describedby="consent-copy"
-                >
-                  <span class="consent-toggle__surface" aria-hidden="true">
-                    <span class="consent-toggle__copy">
-                      <span class="consent-toggle__option consent-toggle__option--yes"
-                        >Yes, I agree to be contacted about Cloud Network Purdue events and opportunities</span
-                      >
-                      <span class="consent-toggle__option consent-toggle__option--no"
-                        >No, I do not agree to be contacted</span
-                      >
-                    </span>
-                    <span class="consent-toggle__divider" aria-hidden="true"></span>
+              <div class="form-consent">
+                <input type="hidden" name="consent" value="0" data-consent-fallback />
+                <input
+                  class="consent-toggle-input"
+                  type="checkbox"
+                  id="consent"
+                  name="consent"
+                  value="1"
+                  data-consent-checkbox
+                  checked
+                />
+                <label class="consent-toggle" for="consent">
+                  <span class="consent-toggle-track" aria-hidden="true">
+                    <span class="consent-toggle-thumb"></span>
                   </span>
-                  <span class="consent-toggle__thumb" aria-hidden="true">
-                    <span class="consent-toggle__thumb-glow"></span>
-                    <span class="consent-toggle__thumb-icon consent-toggle__thumb-icon--up" aria-hidden="true"></span>
-                    <span class="consent-toggle__thumb-icon consent-toggle__thumb-icon--down" aria-hidden="true"></span>
+                  <span class="consent-toggle-text">
+                    I agree to be contacted about Cloud Network Purdue events and opportunities.
                   </span>
-                  <span class="visually-hidden" data-consent-label>
-                    Yes, I agree to be contacted about Cloud Network Purdue events and opportunities
-                  </span>
-                </button>
-                <p id="consent-copy">
-                  I agree to be contacted about Cloud Network Purdue events and opportunities.
-                </p>
+                </label>
               </div>
               <div class="form-actions">
                 <button class="button" type="submit" data-submit-button>Submit RSVP</button>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -758,237 +758,106 @@ textarea {
 
 .form-consent {
   margin-top: 1.75rem;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.75rem 1rem;
-  align-items: center;
+  width: 100%;
+  max-width: 520px;
 }
 
-.form-consent p {
-  margin: 0;
-  text-transform: none;
-  letter-spacing: normal;
-  font-size: 0.95rem;
-  color: var(--text-primary);
-  line-height: 1.6;
+.consent-toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .consent-toggle {
-  --thumb-offset: 38px;
-  position: relative;
-  width: min(100%, 360px);
-  min-height: 6.5rem;
-  padding: 0;
-  border: none;
-  background: transparent;
-  border-radius: 1.25rem;
-  font-family: inherit;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  padding: 0.85rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.7);
   color: inherit;
-  cursor: grab;
-  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, transform 0.25s ease;
+}
+
+.consent-toggle-track {
+  position: relative;
+  flex-shrink: 0;
+  width: 3.25rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  display: flex;
+  align-items: center;
+  padding: 0 0.25rem;
+  transition: background 0.25s ease, box-shadow 0.25s ease;
+}
+
+.consent-toggle-thumb {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: var(--text-primary);
+  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.25);
+  transform: translateX(0);
+  transition: transform 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+}
+
+.consent-toggle-text {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text-primary);
 }
 
 .consent-toggle:hover {
-  transform: translateY(-2px);
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.4);
 }
 
-.consent-toggle:active {
-  transform: translateY(1px);
-}
-
-.consent-toggle.is-dragging {
-  cursor: grabbing;
-}
-
-.consent-toggle:focus-visible {
+.consent-toggle-input:focus-visible + .consent-toggle {
   outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.2);
 }
 
-.consent-toggle:focus-visible .consent-toggle__surface {
-  border-color: rgba(56, 189, 248, 0.75);
-  box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.28), 0 30px 60px rgba(14, 165, 233, 0.35);
+.consent-toggle-input:checked + .consent-toggle {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(15, 23, 42, 0.82);
+  box-shadow: 0 18px 35px rgba(56, 189, 248, 0.18);
 }
 
-.consent-toggle__surface {
-  position: relative;
-  display: block;
-  width: 100%;
-  height: 100%;
-  border-radius: inherit;
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  background:
-    radial-gradient(circle at 20% 10%, rgba(56, 189, 248, 0.2), transparent 55%),
-    radial-gradient(circle at 80% 20%, rgba(56, 189, 248, 0.12), transparent 45%),
-    linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(2, 132, 199, 0.2));
-  box-shadow: 0 30px 55px rgba(3, 7, 18, 0.65), inset 0 1px 6px rgba(255, 255, 255, 0.08), inset 0 -8px 20px rgba(2, 6, 23, 0.85);
-  overflow: hidden;
+.consent-toggle-input:checked + .consent-toggle .consent-toggle-track {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.75));
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
 }
 
-.consent-toggle__surface::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 100%, rgba(56, 189, 248, 0.18), transparent 70%);
-  mix-blend-mode: screen;
-  opacity: 0.7;
-  pointer-events: none;
-}
-
-.consent-toggle__copy {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.4rem 1.6rem;
-  height: 200%;
-  gap: 0;
-  text-align: center;
-  transform: translateY(0%);
-  transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
-  will-change: transform;
-}
-
-.consent-toggle[aria-pressed="false"] .consent-toggle__copy {
-  transform: translateY(-50%);
-}
-
-.consent-toggle__option {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 50%;
-  width: 100%;
-  padding: 0.5rem 0.35rem;
-  font-size: 0.92rem;
-  line-height: 1.45;
-  letter-spacing: 0.02em;
-  font-weight: 600;
-  text-transform: none;
-  text-shadow: 0 0 14px rgba(15, 23, 42, 0.5);
-}
-
-.consent-toggle__option--yes {
-  color: rgba(125, 211, 252, 0.95);
-}
-
-.consent-toggle__option--no {
-  color: rgba(226, 232, 240, 0.8);
-}
-
-.consent-toggle__divider {
-  position: absolute;
-  top: 50%;
-  left: 12%;
-  right: 12%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(56, 189, 248, 0.45), transparent);
-  opacity: 0.6;
-  transform: translateY(-50%);
-}
-
-.consent-toggle__thumb {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 78%;
-  height: 3.1rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(14, 165, 233, 0.85));
-  transform: translate(-50%, var(--thumb-offset));
-  transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1), filter 0.3s ease;
-  box-shadow: 0 24px 45px rgba(14, 165, 233, 0.35), inset 0 1px 3px rgba(255, 255, 255, 0.55);
-  overflow: hidden;
-}
-
-.consent-toggle.is-dragging .consent-toggle__thumb {
-  filter: brightness(1.05);
-}
-
-.consent-toggle__thumb::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.45), transparent 70%);
-  opacity: 0.6;
-  pointer-events: none;
-}
-
-.consent-toggle__thumb-glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.75), transparent 60%);
-  mix-blend-mode: screen;
-  opacity: 0.6;
-}
-
-.consent-toggle__thumb-icon {
-  position: absolute;
-  left: 50%;
-  width: 12px;
-  height: 12px;
-  border: 2px solid rgba(15, 23, 42, 0.7);
-  border-left: none;
-  border-top: none;
-  transform-origin: center;
-  opacity: 0.75;
-}
-
-.consent-toggle__thumb-icon--up {
-  top: 0.55rem;
-  transform: translateX(-50%) rotate(-135deg);
-}
-
-.consent-toggle__thumb-icon--down {
-  bottom: 0.55rem;
-  transform: translateX(-50%) rotate(45deg);
-}
-
-.consent-toggle[aria-pressed="false"] {
-  --thumb-offset: -38px;
-}
-
-.consent-toggle[aria-pressed="false"] .consent-toggle__surface {
-  border-color: rgba(248, 113, 113, 0.5);
-  background:
-    radial-gradient(circle at 20% 20%, rgba(248, 113, 113, 0.25), transparent 60%),
-    radial-gradient(circle at 75% 15%, rgba(217, 70, 239, 0.16), transparent 45%),
-    linear-gradient(160deg, rgba(63, 12, 94, 0.92), rgba(190, 24, 93, 0.28));
-  box-shadow: 0 32px 60px rgba(76, 5, 25, 0.6), inset 0 1px 6px rgba(255, 228, 230, 0.18), inset 0 -8px 18px rgba(59, 7, 15, 0.85);
-}
-
-.consent-toggle[aria-pressed="false"] .consent-toggle__option--no {
-  color: rgba(254, 202, 202, 0.95);
-  text-shadow: 0 0 18px rgba(248, 113, 113, 0.65);
-}
-
-.consent-toggle[aria-pressed="false"] .consent-toggle__thumb {
-  background: linear-gradient(135deg, rgba(248, 113, 113, 0.95), rgba(219, 39, 119, 0.85));
-  box-shadow: 0 24px 45px rgba(225, 29, 72, 0.35), inset 0 1px 3px rgba(255, 255, 255, 0.45);
-}
-
-.consent-toggle[aria-pressed="false"] .consent-toggle__thumb::after {
-  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.35), transparent 65%);
+.consent-toggle-input:checked + .consent-toggle .consent-toggle-thumb {
+  transform: translateX(1.4rem);
+  background: #0ea5e9;
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.3);
 }
 
 @media (max-width: 600px) {
+  .form-consent {
+    max-width: 100%;
+  }
+
   .consent-toggle {
-    width: 100%;
-    min-height: 5.75rem;
+    padding: 0.8rem 1rem;
+    gap: 0.85rem;
   }
 
-  .consent-toggle__copy {
-    padding: 1.2rem 1.4rem;
-    gap: 0;
-  }
-
-  .consent-toggle__option {
-    font-size: 0.88rem;
-  }
-
-  .consent-toggle__thumb {
-    width: 82%;
+  .consent-toggle-text {
+    font-size: 0.9rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the experimental consent control with a checkbox-driven toggle that submits 1/0 to PHP
- restyle the toggle to match the site's modern aesthetic with a pill switch and transitions
- simplify the consent logic in main.js so the hidden fallback only posts when the toggle is off

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcef6866f0832d8518e88ed393605e