### PR TITLE
Refine consent toggle styling on apply page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -759,7 +759,12 @@ textarea {
 .form-consent {
   margin-top: 1.75rem;
   width: 100%;
-  max-width: 520px;
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .consent-toggle-input {
@@ -776,84 +781,97 @@ textarea {
 }
 
 .consent-toggle {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 1rem;
-  width: 100%;
-  padding: 0.85rem 1.2rem;
+  gap: 0.75rem;
+  padding: 0.7rem 1rem;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(15, 23, 42, 0.55);
   color: inherit;
   cursor: pointer;
-  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, transform 0.25s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  max-width: 100%;
 }
 
 .consent-toggle-track {
   position: relative;
   flex-shrink: 0;
-  width: 3.25rem;
-  height: 1.75rem;
+  width: 2.9rem;
+  height: 1.5rem;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   display: flex;
   align-items: center;
-  padding: 0 0.25rem;
-  transition: background 0.25s ease, box-shadow 0.25s ease;
+  padding: 0 0.2rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .consent-toggle-thumb {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.1rem;
+  height: 1.1rem;
   border-radius: 999px;
   background: var(--text-primary);
-  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.25);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
   transform: translateX(0);
-  transition: transform 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .consent-toggle-text {
   font-size: 0.95rem;
-  line-height: 1.6;
+  line-height: 1.45;
   color: var(--text-primary);
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .consent-toggle:hover {
-  transform: translateY(-1px);
-  border-color: rgba(56, 189, 248, 0.4);
+  background: rgba(15, 23, 42, 0.65);
+  border-color: rgba(148, 163, 184, 0.36);
 }
 
 .consent-toggle-input:focus-visible + .consent-toggle {
   outline: none;
-  border-color: rgba(56, 189, 248, 0.6);
-  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.2);
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 0 0 2px rgba(2, 6, 23, 0.85), 0 0 0 5px rgba(56, 189, 248, 0.28);
 }
 
 .consent-toggle-input:checked + .consent-toggle {
   border-color: rgba(56, 189, 248, 0.55);
-  background: rgba(15, 23, 42, 0.82);
-  box-shadow: 0 18px 35px rgba(56, 189, 248, 0.18);
+  background: rgba(15, 23, 42, 0.72);
 }
 
 .consent-toggle-input:checked + .consent-toggle .consent-toggle-track {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.75));
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+  border-color: rgba(14, 165, 233, 0.5);
 }
 
 .consent-toggle-input:checked + .consent-toggle .consent-toggle-thumb {
   transform: translateX(1.4rem);
-  background: #0ea5e9;
-  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.3);
+  background: #e0f2fe;
+  box-shadow: 0 6px 16px rgba(14, 165, 233, 0.3);
+}
+
+.consent-toggle-input:disabled + .consent-toggle {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.consent-toggle-input:disabled + .consent-toggle .consent-toggle-track {
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.22);
 }
 
 @media (max-width: 600px) {
   .form-consent {
     max-width: 100%;
+    gap: 0.65rem;
   }
 
   .consent-toggle {
-    padding: 0.8rem 1rem;
-    gap: 0.85rem;
+    padding: 0.65rem 0.85rem;
+    gap: 0.65rem;
   }
 
   .consent-toggle-text {


### PR DESCRIPTION
## Summary
- restyle the consent toggle to sit inline with its label and wrap gracefully on narrow screens
- dial in hover, focus, active, and disabled treatments so the control matches the rest of the form styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcf446464c832db54df9e80b164729