### PR TITLE
Update asset cache busting version to 01.10.25.5.53

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.44" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.53" />
   </head>
   <body>
     <header class="site-header">
@@ -420,6 +420,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.44" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
   </body>
 </html>

--- a/apply.html
+++ b/apply.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.44" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.53" />
   </head>
   <body>
     <header class="site-header">
@@ -326,6 +326,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.44" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.44" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.53" />
   </head>
   <body>
     <header class="site-header">
@@ -197,6 +197,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.44" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
   </body>
 </html>

--- a/storyline.html
+++ b/storyline.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.44" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.53" />
   </head>
   <body>
     <header class="site-header">
@@ -197,6 +197,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.44" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update HTML pages to reference the latest cache-busting query string for the shared stylesheet
- bump the main JavaScript asset query string to keep it in sync across all pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcf9a6e9c0832da54f7ad1761ef9fe