### PR TITLE
Bump asset cache-busting query versions

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.55" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.65" />
   </head>
   <body>
     <header class="site-header">
@@ -420,6 +420,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.63" defer></script>
   </body>
 </html>

--- a/apply.html
+++ b/apply.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.55" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.65" />
   </head>
   <body>
     <header class="site-header">
@@ -324,6 +324,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.63" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.55" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.65" />
   </head>
   <body>
     <header class="site-header">
@@ -208,6 +208,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.63" defer></script>
   </body>
 </html>

--- a/storyline.html
+++ b/storyline.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.55" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.65" />
   </head>
   <body>
     <header class="site-header">
@@ -197,6 +197,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.53" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.5.63" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- bump the CSS cache-busting query parameter to 01.10.25.5.65 across site pages
- bump the JavaScript cache-busting query parameter to 01.10.25.5.63 across site pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0b09cc38832db79bc6e4eb7a0198