### PR TITLE
Comment out RSVP banner and rename apply form

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -157,7 +157,7 @@
       <section class="section" aria-labelledby="rsvp-form">
         <div class="wrapper split-layout">
           <article>
-            <h2 id="rsvp-form" class="section-title" data-animate>RSVP form</h2>
+            <h2 id="rsvp-form" class="section-title" data-animate>Join Us Form</h2>
             <p class="text-muted" data-animate>
               Share how we can reach you and what you’re studying. Required fields are marked and everything else is
               optional context that helps us tailor the right Cloud Network experience.

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
     </header>
 
     <main>
+      <!--
       <section class="rsvp-banner" data-rsvp-banner hidden>
         <div class="wrapper">
           <div class="rsvp-banner__inner" role="status" aria-live="polite">
@@ -56,6 +57,7 @@
           </div>
         </div>
       </section>
+      -->
       <section class="hero" aria-labelledby="hero-title">
         <div class="wrapper hero-grid">
           <div>


### PR DESCRIPTION
## Summary
- comment out the homepage RSVP banner wrapper so the template can be reused later
- rename the application form heading to "Join Us Form" on apply.html

## Testing
- no automated tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e0975df698832dbbd0aae7e9da3ed8