### PR TITLE
Add movie night RSVP banner and returning form flow

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -157,33 +157,25 @@
       <section class="section" aria-labelledby="rsvp-form">
         <div class="wrapper split-layout">
           <article>
-            <h2 id="rsvp-form" class="section-title" data-animate>Join Us Form</h2>
+            <h2 id="rsvp-form" class="section-title" data-animate>Movie Night RSVP Form</h2>
             <p class="text-muted" data-animate>
               Share how we can reach you and what you’re studying. Required fields are marked and everything else is
               optional context that helps us tailor the right Cloud Network experience.
             </p>
-            <form class="form-card" action="/api/rsvp.php" method="POST" data-rsvp-form data-animate>
+            <form
+              class="form-card"
+              action="/api/rsvp.php"
+              method="POST"
+              data-rsvp-form
+              data-lookup-endpoint="/api/rsvp.php"
+              data-animate
+            >
               <div class="honeypot-field" aria-hidden="true">
                 <label for="apply-honey">Leave this field empty</label>
                 <input id="apply-honey" name="honey" type="text" tabindex="-1" autocomplete="off" data-honey />
               </div>
               <div class="form-grid">
-                <div>
-                  <label for="full_name"
-                    >Full name<span aria-hidden="true" class="required-indicator">*</span
-                    ><span class="visually-hidden"> required</span></label
-                  >
-                  <input
-                    id="full_name"
-                    name="full_name"
-                    type="text"
-                    placeholder="Jordan Rivera"
-                    autocomplete="name"
-                    maxlength="80"
-                    required
-                  />
-                </div>
-                <div>
+                <div data-field-group="email">
                   <label for="email"
                     >Email<span aria-hidden="true" class="required-indicator">*</span
                     ><span class="visually-hidden"> required</span></label
@@ -198,7 +190,22 @@
                     required
                   />
                 </div>
-                <div>
+                <div data-field-group="full_name">
+                  <label for="full_name"
+                    >Full name<span aria-hidden="true" class="required-indicator">*</span
+                    ><span class="visually-hidden"> required</span></label
+                  >
+                  <input
+                    id="full_name"
+                    name="full_name"
+                    type="text"
+                    placeholder="Jordan Rivera"
+                    autocomplete="name"
+                    maxlength="80"
+                    required
+                  />
+                </div>
+                <div data-field-group="phone">
                   <label for="phone">Phone</label>
                   <div class="input-with-prefix" data-phone-wrapper>
                     <span aria-hidden="true" class="input-prefix">+1</span>
@@ -214,7 +221,7 @@
                     />
                   </div>
                 </div>
-                <div>
+                <div data-field-group="major">
                   <label for="major">Major</label>
                   <select id="major" name="major" autocomplete="organization" data-major-select>
                     <option value="">Select your major</option>
@@ -238,7 +245,7 @@
                     />
                   </div>
                 </div>
-                <div>
+                <div data-field-group="grad_year">
                   <label for="grad_year">Graduation year</label>
                   <input
                     id="grad_year"
@@ -252,7 +259,7 @@
                   />
                 </div>
               </div>
-              <div style="margin-top: 1.5rem">
+              <div style="margin-top: 1.5rem" data-field-group="notes">
                 <label for="notes">Anything else we should know?</label>
                 <textarea
                   id="notes"
@@ -261,7 +268,7 @@
                   rows="5"
                 ></textarea>
               </div>
-              <div class="form-consent">
+              <div class="form-consent" data-field-group="consent">
                 <input type="hidden" name="consent" value="0" data-consent-fallback />
                 <input
                   class="consent-toggle-input"
@@ -282,7 +289,18 @@
                 </label>
               </div>
               <div class="form-actions">
-                <button class="button" type="submit" data-submit-button>Submit RSVP</button>
+                <button
+                  class="button"
+                  type="submit"
+                  data-submit-button
+                  data-submitting-text="Submitting..."
+                  data-success-text="Submitted!"
+                  data-returning-text="Confirm RSVP"
+                  data-returning-submitting-text="Confirming..."
+                  data-returning-success-text="Confirmed!"
+                >
+                  Submit RSVP
+                </button>
                 <div class="form-status" data-form-feedback aria-live="polite" role="status"></div>
               </div>
             </form>
@@ -324,6 +342,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.63" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.6.00" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,11 +45,16 @@
     </header>
 
     <main>
-      <!--
-      <section class="rsvp-banner" data-rsvp-banner hidden>
+      <section
+        class="rsvp-banner"
+        data-rsvp-banner
+        data-rsvp-event="movie-night-2025-10-10"
+        data-rsvp-cookie="tcn_rsvp_prompt_movie_night_20251010"
+        hidden
+      >
         <div class="wrapper">
           <div class="rsvp-banner__inner" role="status" aria-live="polite">
-            <p class="rsvp-banner__message">Here to RSVP for the callouts on 3rd of October - 8PM (WALC 1055)?</p>
+            <p class="rsvp-banner__message">Are you here to RSVP for the Movie Night on the 10th Oct 2025 – 6:45 PM?</p>
             <div class="rsvp-banner__actions">
               <button type="button" class="button" data-rsvp-choice="yes">Yes</button>
               <button type="button" class="button secondary" data-rsvp-choice="no">No</button>
@@ -57,7 +62,6 @@
           </div>
         </div>
       </section>
-      -->
       <section class="hero" aria-labelledby="hero-title">
         <div class="wrapper hero-grid">
           <div>
@@ -210,6 +214,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.5.63" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.6.00" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- re-enable the landing-page RSVP banner with event-specific copy and cookie configuration for the movie night
- retitle and reorder the RSVP form inputs, exposing data attributes for returning-user handling
- add email domain lookup, returning user mode, and event-specific cookie utilities in the client script

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e448db48f4832d97e71ad3da9e94ab