### PR TITLE
Add already-registered RSVP detection and banner

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -27,7 +27,7 @@
     />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="favicon.ico" />
-    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.65" />
+    <link rel="stylesheet" href="assets/css/style.css?V=01.10.25.5.66" />
   </head>
   <body>
     <header class="site-header">
@@ -174,6 +174,12 @@
                 <label for="apply-honey">Leave this field empty</label>
                 <input id="apply-honey" name="honey" type="text" tabindex="-1" autocomplete="off" data-honey />
               </div>
+              <div class="already-registered-banner" data-already-registered role="status" aria-live="polite" hidden>
+                <div class="already-registered-inner">
+                  <p class="already-registered-message">🎉 You are already registered for this event</p>
+                  <p class="already-registered-name" data-already-registered-name></p>
+                </div>
+              </div>
               <div class="form-grid">
                 <div data-field-group="email">
                   <label for="email"
@@ -288,7 +294,7 @@
                   </span>
                 </label>
               </div>
-              <div class="form-actions">
+              <div class="form-actions" data-form-actions>
                 <button
                   class="button"
                   type="submit"
@@ -342,6 +348,6 @@
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>
-    <script src="assets/js/main.js?V=01.10.25.6.00" defer></script>
+    <script src="assets/js/main.js?V=01.10.25.6.01" defer></script>
   </body>
 </html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -738,6 +738,57 @@ textarea {
   overflow: hidden;
 }
 
+.already-registered-banner {
+  background: rgba(34, 197, 94, 0.14);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+  border-radius: 0.75rem;
+  padding: 1.1rem 1.25rem;
+  margin-bottom: 1.75rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--text-primary);
+  box-shadow: 0 18px 48px rgba(16, 185, 129, 0.18);
+}
+
+.already-registered-banner[hidden] {
+  display: none;
+}
+
+.already-registered-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.already-registered-message {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: rgba(236, 253, 245, 0.9);
+}
+
+.already-registered-name {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(190, 242, 217, 0.95);
+  letter-spacing: 0.02em;
+}
+
+.input-is-locked {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(74, 222, 128, 0.45);
+  color: var(--text-primary);
+  cursor: default;
+}
+
+.input-is-locked:focus {
+  border-color: rgba(74, 222, 128, 0.65);
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.25);
+}
+
 .input-with-prefix {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- add a lookup handler in `api/rsvp.php` that returns the current event slug alongside existing RSVP data
- surface an accessible “already registered” banner in the RSVP form and hide other inputs when the latest RSVP matches the current event
- refine the front-end lookup flow to trigger on blur, handle network errors, and style the locked state/banner

## Testing
- php -l api/rsvp.php

------
https://chatgpt.com/codex/tasks/task_e_68e483eaf27c832db36663305a51298e