### PR TITLE
Embed Luma RSVP iframe and comment out legacy Movie Night form

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -162,6 +162,7 @@
               Share how we can reach you and what you’re studying. Required fields are marked and everything else is
               optional context that helps us tailor the right Cloud Network experience.
             </p>
+            <!--
             <form
               class="form-card"
               action="/api/rsvp.php"
@@ -310,6 +311,19 @@
                 <div class="form-status" data-form-feedback aria-live="polite" role="status"></div>
               </div>
             </form>
+            -->
+            <div class="form-card" data-animate>
+              <iframe
+                src="https://luma.com/embed/event/evt-biSf4y8NzwLzhfv/simple"
+                width="600"
+                height="450"
+                frameborder="0"
+                style="border: 1px solid #bfcbda88; border-radius: 4px; width: 100%; max-width: 600px"
+                allow="fullscreen; payment"
+                aria-hidden="false"
+                tabindex="0"
+              ></iframe>
+            </div>
           </article>
           <!--
           <aside class="layer-card" data-animate>


### PR DESCRIPTION
### Motivation
- Replace the in-house Movie Night RSVP form with the provided Luma embed so RSVPs are handled by the external form while preserving the original form markup for future reuse.
- Keep the new embed in the same location and ensure it does not break the existing layout on mobile or desktop.

### Description
- Commented out the entire original Movie Night `<form>` block in `apply.html` instead of deleting it so the legacy form remains in the codebase for possible reuse.
- Added the requested Luma `<iframe>` (`https://luma.com/embed/event/evt-biSf4y8NzwLzhfv/simple`) inside a `div.form-card` in the same RSVP section.
- Applied responsive sizing to the iframe with inline styles (`width: 100%; max-width: 600px`) and retained the provided border and accessibility attributes.

### Testing
- Verified the updated file contains the commented-out `<form>` and the new `<iframe>` by running `rg -n "<iframe|<form|Movie Night RSVP Form" /workspace/Thecloudnetwork/apply.html`, which returned the expected matches.
- Inspected the modified region with `nl -ba /workspace/Thecloudnetwork/apply.html | sed -n '150,345p'` to confirm the comment boundaries and iframe placement, and the command completed successfully.
- Confirmed the change was staged and committed locally; no browser rendering tests were run in this environment so visual verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31b419828832da76903feffeb7567)