### PR TITLE
Replace RSVP form with Luma embed for Website Building Workshop

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -157,11 +157,18 @@
       <section class="section" aria-labelledby="rsvp-form">
         <div class="wrapper split-layout">
           <article>
+            <!--
             <h2 id="rsvp-form" class="section-title" data-animate>Movie Night RSVP Form</h2>
             <p class="text-muted" data-animate>
               Share how we can reach you and what you’re studying. Required fields are marked and everything else is
               optional context that helps us tailor the right Cloud Network experience.
             </p>
+            -->
+            <h2 id="rsvp-form" class="section-title" data-animate>Website Building Workshop Form</h2>
+            <p class="text-muted" data-animate>
+              Reserve your spot for our Website Building Workshop and complete registration through the form below.
+            </p>
+            <!--
             <form
               class="form-card"
               action="/api/rsvp.php"
@@ -310,6 +317,19 @@
                 <div class="form-status" data-form-feedback aria-live="polite" role="status"></div>
               </div>
             </form>
+            -->
+            <div class="form-card" data-animate>
+              <iframe
+                src="https://luma.com/embed/event/evt-biSf4y8NzwLzhfv/simple"
+                width="900"
+                height="650"
+                frameborder="0"
+                style="border: 1px solid #bfcbda88; border-radius: 4px; max-width: 100%;"
+                allow="fullscreen; payment"
+                aria-hidden="false"
+                tabindex="0"
+              ></iframe>
+            </div>
           </article>
           <!--
           <aside class="layer-card" data-animate>


### PR DESCRIPTION
### Motivation
- Replace the on-site RSVP flow and Movie Night copy on the apply page with an embedded external registration for a Website Building Workshop to streamline signups.

### Description
- Updated `apply.html` to comment out the original Movie Night header and the full in-page RSVP `form` markup.
- Added a new visible section header and description for the "Website Building Workshop Form" in place of the previous copy.
- Inserted a `div.form-card` containing an `iframe` that embeds the Luma event at `https://luma.com/embed/event/evt-biSf4y8NzwLzhfv/simple` with layout and accessibility attributes.
- Preserved the original form markup in HTML comments for easy rollback.

### Testing
- No automated tests were added or modified and no CI tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31b419828832da76903feffeb7567)